### PR TITLE
Fix `winner` in `show_result.py` for game 2

### DIFF
--- a/show_result.py
+++ b/show_result.py
@@ -158,14 +158,14 @@ def get_battles_from_judgment(judge_name, first_game_only=False, WEIGHT=3):
                 if game["score"] == "A=B":
                     output["winner"] = "tie"
                 elif game["score"] == "A>B":
-                    output["winner"] = "model_b"
+                    output["winner"] = "model_a"
                 elif game["score"] == "A>>B":
-                    output["winner"] = "model_b"
+                    output["winner"] = "model_a"
                     weight = WEIGHT
                 elif game["score"] == "B>A":
-                    output["winner"] = "model_a"
+                    output["winner"] = "model_b"
                 elif game["score"] == "B>>A":
-                    output["winner"] = "model_a"
+                    output["winner"] = "model_b"
                     weight = WEIGHT
                 else:
                     weight = 0


### PR DESCRIPTION
## Description

This PR fixes a bug within the `winner` field for the game 2, since when either `A>B` or `A>>B` the winner is set to `model_b` while it should be `model_a`; also applies to the other way around.

cc @CodingWithTim 