### PR TITLE
Fix incorrect variable reference for reference answers

### DIFF
--- a/gen_judgment.py
+++ b/gen_judgment.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
         
     if configs["reference"]:
         assert not configs["reference"] in models, "ERROR: one of the models being evaluated is used as reference."
-        ref_answers = [answer_dir[model] for model in configs["reference"]]
+        ref_answers = [model_answers[model] for model in configs["reference"]]
     else:
         ref_answers = None
     


### PR DESCRIPTION
Replaced `answer_dir` with `model_answers` when loading reference answers.
`answer_dir` is a path string, not a mapping of model names to answers.
Using `model_answers` correctly retrieves the answers for reference models.
